### PR TITLE
feat: Add the compiled bundle to npm.

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,7 @@
+.DS_Store
+.env
+node_modules/
+stamp-yarn
+stats.json
+yarn-error.log
+*.zip

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,22 @@
+# This Makefile is meant to be exported by Patternslib or Mockup packages.
+
+# .evn include, mainly for a GITHUB_TOKEN.
 -include .env
 export
+
+
+# If you want to release on GitHub, make sure to have a .env file with a GITHUB_TOKEN.
+# Also see:
+#	https://github.com/settings/tokens
+#	and https://github.com/release-it/release-it/blob/master/docs/github-releases.md#automated
+
 
 ESLINT ?= npx eslint
 YARN   ?= npx yarn
 
 PACKAGE_DEV=@patternslib/dev
 PACKAGE_NAME := $(shell node -p "require('./package.json').name")
+BUNDLE_NAME := $(subst @patternslib/,,$(subst @plone/,,$(PACKAGE_NAME)))
 
 .PHONY: install
 stamp-yarn install:
@@ -43,6 +54,7 @@ bundle-pre:
 	@#         yarn install --force
 
 
+# Compile the bundle.
 .PHONY: bundle
 bundle: bundle-pre stamp-yarn
 ifneq "$(PACKAGE_NAME)" "$(PACKAGE_DEV)"
@@ -51,58 +63,104 @@ ifneq "$(PACKAGE_NAME)" "$(PACKAGE_DEV)"
 endif
 
 
-# If you want to release on GitHub, make sure to have a .env file with a GITHUB_TOKEN.
-# Also see:
-#	https://github.com/settings/tokens
-#	and https://github.com/release-it/release-it/blob/master/docs/github-releases.md#automated
-
-
+# Create a ZIP file from the bundle which is uploaded to the GitHub release tag.
 release-zip: clean-dist bundle
 ifneq "$(PACKAGE_NAME)" "$(PACKAGE_DEV)"
 	@# Do not create a zip release for @patternslib/dev
-	$(eval BUNDLE_NAME := $(subst @patternslib/,,$(subst @plone/,,$(PACKAGE_NAME))))
 	$(eval PACKAGE_VERSION := $(shell node -p "require('./package.json').version"))
 	@echo Creating $(BUNDLE_NAME)-bundle-$(PACKAGE_VERSION).zip
-	mkdir -p dist/$(BUNDLE_NAME)-bundle-$(PACKAGE_VERSION)
-	-mv dist/* dist/$(BUNDLE_NAME)-bundle-$(PACKAGE_VERSION)
-	cd dist/ && zip -r $(BUNDLE_NAME)-bundle-$(PACKAGE_VERSION).zip $(BUNDLE_NAME)-bundle-$(PACKAGE_VERSION)/
+	mkdir -p $(BUNDLE_NAME)-bundle-$(PACKAGE_VERSION)
+	-cp -R dist/* $(BUNDLE_NAME)-bundle-$(PACKAGE_VERSION)
+	zip -r $(BUNDLE_NAME)-bundle-$(PACKAGE_VERSION).zip $(BUNDLE_NAME)-bundle-$(PACKAGE_VERSION)/
+	rm -Rf $(BUNDLE_NAME)-bundle-$(PACKAGE_VERSION)
 endif
 
 
+# Update the package.json version with NEXT_VERSION
+define write_package_json
+const fs = require("fs"); \
+const package_json = require("./package.json"); \
+package_json.version = "$(NEXT_VERSION)"; \
+const data = JSON.stringify(package_json, null, 4); \
+fs.writeFileSync("package.json", data);
+endef
+
+prepare-release:
+	@# Get the current package version.
+	$(eval CURRENT_VERSION := $(shell node -p "require('./package.json').version"))
+ifeq ($(LEVEL),$(filter $(LEVEL), alpha beta))
+	@# case alpha or beta pre-release
+
+	@# Set level argument for release-it.
+	$(eval RELEASE_IT_LEVEL := "--preRelease=$(LEVEL)")
+	@# Get the next version via semver.
+	$(eval NEXT_VERSION := $(shell npx semver --increment premajor --preid $(LEVEL) $(CURRENT_VERSION)))
+else
+	@# case normal major/minor/patch release
+
+	@# Set level argument for release-it.
+	$(eval RELEASE_IT_LEVEL := $(LEVEL))
+	@# Get the next version via semver.
+	$(eval NEXT_VERSION := $(shell npx semver --increment $(LEVEL) $(CURRENT_VERSION)))
+endif
+	@echo Next version is: $(NEXT_VERSION)
+
+	@# Temporarily write the NEXT_VERSION to package.json, so that the bundle
+	@# and release-zip generate correct version strings.
+	node -p '$(write_package_json)'
+
+
+release: clean install check prepare-release release-zip
+	@# RELEASE_IT_LEVEL and NEXT_VERSION set by prepare-release
+
+	@# Note: If you want to include the compiled bundle in your npm package you
+	@#       have to allow it in a .npmignore file.
+
+	@# Checkout package.json which was modified by prepare-release and read by
+	@# release-zip.
+	git checkout .
+
+	@# 1) Release on npm.
+	@# 2) When successful, update release on GitHub
+	@# 3) Checkout CHANGES.md, which was modified by step 2)
+	npx release-it $(RELEASE_IT_LEVEL) \
+		&& npx release-it \
+			--github.release \
+			--github.update \
+			--github.assets=$(BUNDLE_NAME)-bundle-$(NEXT_VERSION).zip \
+			--no-github.draft \
+			--no-increment \
+			--no-git \
+			--no-npm
+		&& git checkout CHANGES.md
+
+	@# Remove the bundle from release-zip again.
+	rm $(BUNDLE_NAME)-bundle-$(PACKAGE_VERSION).zip
+
+
 .PHONY: release-major
-release-major: check
-	npx release-it major && \
-		make release-zip && \
-		npx release-it --github.release --github.update --github.assets=dist/*.zip --no-github.draft --no-increment --no-git --no-npm && \
-		git checkout CHANGES.md
+release-major:
+	make LEVEL=major release
+
 
 .PHONY: release-minor
-release-minor: check
-	npx release-it minor && \
-		make release-zip && \
-		npx release-it --github.release --github.update --github.assets=dist/*.zip --no-github.draft --no-increment --no-git --no-npm && \
-		git checkout CHANGES.md
+release-minor:
+	make LEVEL=minor release
+
 
 .PHONY: release-patch
-release-patch: check
-	npx release-it patch && \
-		make release-zip && \
-		npx release-it --github.release --github.update --github.assets=dist/*.zip --no-github.draft --no-increment --no-git --no-npm && \
-		git checkout CHANGES.md
+release-patch:
+	make LEVEL=patch release
+
 
 .PHONY: prerelease-alpha
-prerelease-alpha: clean install
-	npx release-it --preRelease=alpha && \
-		make release-zip && \
-		npx release-it --github.release --github.update --github.assets=dist/*.zip --no-github.draft --no-increment --no-git --no-npm && \
-		git checkout CHANGES.md
+prerelease-alpha:
+	make LEVEL=alpha release
+
 
 .PHONY: prerelease-beta
-prerelease-beta: clean install
-	npx release-it --preRelease=beta && \
-		make release-zip && \
-		npx release-it --github.release --github.update --github.assets=dist/*.zip --no-github.draft --no-increment --no-git --no-npm && \
-		git checkout CHANGES.md
+prerelease-beta:
+	make LEVEL=beta release
 
 
 .PHONY: serve

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
         "release-it": "^15.5.0",
         "sass": "^1.55.0",
         "sass-loader": "^13.1.0",
+        "semver": "^7.3.8",
         "style-loader": "^3.3.0",
         "terser-webpack-plugin": "^5.3.6",
         "timezone-mock": "^1.3.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8421,7 +8421,7 @@ semver@7.3.7, semver@^7.3.7:
   dependencies:
     lru-cache "^6.0.0"
 
-semver@7.3.8:
+semver@7.3.8, semver@^7.3.8:
   version "7.3.8"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.8.tgz#07a78feafb3f7b32347d725e33de7e2a2df67798"
   integrity sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==


### PR DESCRIPTION
This is a non breaking change.

Adding the compiled bundle to npm allows to directly include it via a
CDN like so:

https://cdn.jsdelivr.net/npm/@patternslib/patternslib@9.7.0-alpha.2/dist/bundle.min.js
or
https://unpkg.com/@patternslib/patternslib@9.7.0-alpha.2/dist/bundle.min.js

We have to compile the bundle with the correct version BEFORE the npm
package is created with release-it. The next version is queried using
the LEVEL parameter (set by the different release targets) and the
"semver" tool.