### PR TITLE
fix: Include the correct bundle version in entry file header comment.

### DIFF
--- a/.release-it.js
+++ b/.release-it.js
@@ -45,6 +45,13 @@ module.exports = {
             writerOpts: {
                 commitPartial: commits_template,
             },
+            hooks: {
+                // Run `make build` after the version is bumped to get a build
+                // with the new version number comment in the entry scripts.
+                // Use the make target which does a check to not build if the
+                // package is this `@patternslib/dev` package.
+                "after:bump": "make build",
+            },
         },
     },
 };

--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,8 @@ bundle-pre:
 
 
 # Compile the bundle.
+# NOTE: When using the normal workflow - e.g. `make release-minor`, the
+# relase-it config runs `make build` after the version bump.
 .PHONY: bundle
 bundle: clean-dist bundle-pre stamp-yarn
 ifneq "$(PACKAGE_NAME)" "$(PACKAGE_DEV)"
@@ -128,7 +130,7 @@ release-github: prepare-release release-zip
 	-rm $(BUNDLE_NAME)-bundle-$(PACKAGE_VERSION).zip
 
 
-release: clean install check bundle release-npm release-github
+release: clean install check release-npm release-github
 	@# Note: If you want to include the compiled bundle in your npm package you
 	@#       have to allow it in a .npmignore file.
 


### PR DESCRIPTION
In order to have the correct version specifier in the bundle's entry script header comment the bundle must be built after the version bump. Use release-it hooks to do that.